### PR TITLE
copyright year is now dynamic

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,9 +288,8 @@
         <p>  
         <h3> Designed & Developed by Tejas Gupta</h3>
         </p>
-        <!--<p>
-            <h4>Copyright &copy; 2024 Tejas Gupta</h4>
-        </p>-->
+        <br>
+        <h4>Copyright &copy; <span id="copyright"></span> Tejas Gupta</h4>
         <div class="end_line"></div>
         <div class="small">
             <div class="link_class">

--- a/website/license.html
+++ b/website/license.html
@@ -84,13 +84,16 @@
                 background: linear-gradient(180deg,silver,rgb(194, 187, 187));
                 padding: 10px;
                 color: whitesmoke;
+                display: flex;
+                justify-content: center;
             }
         </style>
 
         
-        <footer>
-        <h3>Copyright &copy; 2024 Tejas Gupta</h3>
+    <footer>
+        <h3>Copyright &copy; <span id="copyright"></span> Tejas Gupta</h3>
     </footer>
+    
         <br>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal

--- a/website/license.js
+++ b/website/license.js
@@ -33,6 +33,7 @@ function hide() {
 }
 
 function systemDefault() {
+  displayCopyright();
   const theme = localStorage.getItem('theme');
 
   if (theme === 'light') {
@@ -87,6 +88,12 @@ function dark(flag) {
   }
   indicator.style.backgroundImage = "radial-gradient(rgba(255,255,255, 0.608),#00000000,#00000000)";
   shadow.style.backgroundImage = "linear-gradient(115deg, #00000000,#000000d4,#00000000)";
+}
+
+// Display the current year in the copyright section
+function displayCopyright() {
+  const year = new Date().getFullYear();
+  document.getElementById("copyright").innerText = year;
 }
 
 systemDefault();

--- a/website/script.js
+++ b/website/script.js
@@ -5,6 +5,7 @@ var cities = ["Pune", "Moradabad", "Dehradun","Rampur","Delhi","Coimbatore"];
 let preloader = document.querySelector("#preloader");
 window.addEventListener("load",function(e){
     preloader.style.display = "none";
+    displayCopyright();
 });
 
 function topFunction() {
@@ -414,4 +415,10 @@ function validateForm() {
 function isValidEmail(email) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
+}
+
+// Display the current year in the copyright section
+function displayCopyright() {
+    const year = new Date().getFullYear();
+    document.getElementById("copyright").innerText = year;
 }


### PR DESCRIPTION
### Description
I have created this PR to resolve the problem of hardcoded copyright year. and make it dynamic. After merging this PR, the changes will be reflected into both the footer section of home page as well as the license page as they will show the present year, and not the hardcoded one.

**Hardcoded year.....(2020 was written only for display purpose to compare)**
<img width="992" alt="Screenshot 2024-10-14 at 7 28 01 PM" src="https://github.com/user-attachments/assets/a7614215-162c-4e3c-838a-c858c51fc210">
**Still displays present year.....**
<img width="1440" alt="Screenshot 2024-10-14 at 7 30 34 PM" src="https://github.com/user-attachments/assets/a93a8146-8e4e-45f4-9ed5-78333f86a6b5">
As you can see even if we now hardcode the copyright year, it will only display present year, so when the year changes we don't need to manually change the copyright year in both footer section of home webpage as well as the license page, it will automatically change
### Related Issue
Fixes #74

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
