### PR TITLE
Make the copyright year dynamic in the LICENSE section.  #74

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,9 +288,8 @@
         <p>  
         <h3> Designed & Developed by Tejas Gupta</h3>
         </p>
-        <!--<p>
-            <h4>Copyright &copy; 2024 Tejas Gupta</h4>
-        </p>-->
+        <br>
+            <h4>Copyright &copy; <span id="copyright">32949832</span> Tejas Gupta</h4>
         <div class="end_line"></div>
         <div class="small">
             <div class="link_class">

--- a/website/license.html
+++ b/website/license.html
@@ -82,12 +82,14 @@
                 background: linear-gradient(180deg,silver,rgb(194, 187, 187));
                 padding: 10px;
                 color: whitesmoke;
+                display: flex;
+                justify-content: center;
             }
         </style>
 
         
         <footer>
-        <h3>Copyright &copy; 2024 Tejas Gupta</h3>
+        <h3>Copyright &copy; <span id="copyright">32949832</span> Tejas Gupta</h3>
     </footer>
         <br>
         Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/website/license.js
+++ b/website/license.js
@@ -105,10 +105,16 @@ function dark(flag) {
     updateIndicator(darkButton);
 }
 
+// Display the current year in the copyright section
+function displayCopyright() {
+    const year = new Date().getFullYear();
+    document.getElementById("copyright").innerText = year;
+  }
+
 function systemDefault() {
     const theme = localStorage.getItem('theme');
     const defaultButton = document.getElementById("defaultButton");
-
+    displayCopyright();
     if (theme === 'light') {
         light(true);
         updateIndicator(document.getElementById("lightButton"));

--- a/website/script.js
+++ b/website/script.js
@@ -5,6 +5,7 @@ var cities = ["Pune", "Moradabad", "Dehradun","Rampur","Delhi","Coimbatore"];
 let preloader = document.querySelector("#preloader");
 window.addEventListener("load",function(e){
     preloader.style.display = "none";
+    displayCopyright();
 });
 
 function topFunction() {
@@ -406,4 +407,10 @@ function validateForm() {
 function isValidEmail(email) {
     const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
     return emailRegex.test(email);
+}
+
+// Display the current year in the copyright section
+function displayCopyright() {
+  const year = new Date().getFullYear();
+  document.getElementById("copyright").innerText = year;
 }

--- a/website/style.css
+++ b/website/style.css
@@ -1053,6 +1053,10 @@ input {
     color: rgba(255, 255, 255, 0.433);
 }
 
+.links h4 {
+    color: rgba(255, 255, 255, 0.433);
+}
+
 .end_line {
     width: 80vw;
     margin-top: 25px;


### PR DESCRIPTION
### Description
I have made the copyright year dynamic. Now even if we hardcode the copyright year in html, it will only show the current year in both the footer section of the Home page as well as the License page


**HOME PAGE...**(i changed my system's date to year 2025 and that too is getting reflected dynamically 👍 )
<img width="1420" alt="Screenshot 2024-10-14 at 7 20 10 PM" src="https://github.com/user-attachments/assets/2ee852c0-744a-4db2-b6e3-644700e09edc">
**LICENSE PAGE...**
<img width="1440" alt="Screenshot 2024-10-14 at 7 30 34 PM" src="https://github.com/user-attachments/assets/756f0747-c5d4-4f8e-8006-b38d326e6aaa">



**As you can see i have written 2020(only for comparing purpose, it still displayes the present year)**
<img width="992" alt="Screenshot 2024-10-14 at 7 28 01 PM" src="https://github.com/user-attachments/assets/ab47c76e-4021-47ea-841a-4ec74bf7e558">
(i have also added 2 line of css to make the line in center using flex, in the license section)

### Related Issue
Fixes #74

### Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
