### PR TITLE
changed the footer link to bright color

### DIFF
--- a/website/style.css
+++ b/website/style.css
@@ -1024,15 +1024,15 @@ input {
 }
 
 .links a {
-    color: rgba(255, 255, 255, 0.433);
+    color:white;
 }
 
 .links h3 {
-    color: rgba(255, 255, 255, 0.433);
+    color: white;
 }
 
 .links h4 {
-    color: rgba(255, 255, 255, 0.433);
+    color: white;
 }
 
 .end_line {


### PR DESCRIPTION
Description
You updated the .links a, .links h3, and .links h4 selectors in the CSS to use a white color instead of the semi-transparent dark color, improving visibility, especially in the footer area.
![Screenshot 2024-10-22 145821](https://github.com/user-attachments/assets/31e91f94-abb4-4cf2-9b9c-59e34d46ead8)

Related Issue
This contribution addresses issue #170 opened by saumyayadav25, which highlighted the dark colors in the footer making the text hard to read.

Type of Change
 Bug fix
Checklist
 Your code follows the style guidelines of the project.
 You performed a self-review of your changes.
 The necessary changes have been made to ensure the fix is effective.
 All existing tests pass locally with your changes.











