### PR TITLE
Added github issue labeler workflow

### DIFF
--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -30,7 +30,7 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
-              "name": "hacktoberfest",
+              "name": "hacktoberfest-accepted",
               "color": "FF7518",
               "description": "Hacktoberfest participation"
             }'

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -1,0 +1,55 @@
+name: Issue Labeler
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  manage-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Create or Update Labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "gssoc-extd",
+              "color": "0E8A16",
+              "description": "GSSOC extended contribution"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "hacktoberfest",
+              "color": "FF7518",
+              "description": "Hacktoberfest participation"
+            }'
+
+          curl -X POST \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/labels \
+            -d '{
+              "name": "level?",
+              "color": "5319E7",
+              "description": "Placeholder for difficulty level"
+            }'
+
+      - name: Add Labels to Issue
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            gssoc-extd
+            hacktoberfest
+            level?

--- a/.github/workflows/issue_labeler.yaml
+++ b/.github/workflows/issue_labeler.yaml
@@ -20,36 +20,14 @@ jobs:
             -H "Accept: application/vnd.github.v3+json" \
             https://api.github.com/repos/${{ github.repository }}/labels \
             -d '{
-              "name": "gssoc-extd",
-              "color": "0E8A16",
-              "description": "GSSOC extended contribution"
+              "name": "Review Queued",
+              "color": "FFAE00",
+              "description": "Pending review"
             }'
 
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/labels \
-            -d '{
-              "name": "hacktoberfest-accepted",
-              "color": "FF7518",
-              "description": "Hacktoberfest participation"
-            }'
-
-          curl -X POST \
-            -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/labels \
-            -d '{
-              "name": "level?",
-              "color": "5319E7",
-              "description": "Placeholder for difficulty level"
-            }'
-
-      - name: Add Labels to Issue
+      - name: Add Label to Issue
         uses: actions-ecosystem/action-add-labels@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: |
-            gssoc-extd
-            hacktoberfest
-            level?
+            Review Queued


### PR DESCRIPTION
## Description:  
This PR adds a GitHub Action to automate labeling of issues on creation or edit.  
The labels added are `gssoc-extd` (green), `hacktoberfest` (orange), and `level?` (purple).  
`level?` serves as a placeholder until the project admin assigns the final level during PR review.  
The workflow uses the GitHub API to ensure labels are updated with correct colors and descriptions

Fix #202 

@multiverseweb 
Pls add labels like level3,gssoc-extd,hacktoberfest-accepted.