### PR TITLE
Fixed the unintended behaviour of the hover effect on the links.

### DIFF
--- a/website/styles/style.css
+++ b/website/styles/style.css
@@ -1098,6 +1098,7 @@ input {
 
 .small a{
     width: fit-content;
+    border-bottom: 1px solid rgba(255, 255, 255, 0);
 }
 
 .small a:hover {


### PR DESCRIPTION
### Description
I made it so that the border is already there, but invisible, and when the user hovers over the links, it will simply change colour, avoiding unintended side effects such as spacing.

### Related Issue
Fixes #311 

### Type of change
- [x] Bug fix
- [ ] New feature

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


https://github.com/user-attachments/assets/9a30d3d5-e304-4d03-8493-ce8d0ccf9410

