### PR TITLE
Implemented infinite scrolling on example images in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,7 +163,7 @@
     <div class="section" id="charts">
         <p class="heading reveal">Here are some examples of what you can do with Dataverse</p>
         <div class="examples reveal" id="examples">
-
+            
             <img src="website/web_images/volcano.gif" alt="">
             <img src="website/web_images/live.gif" alt="">
             <img src="https://i0.wp.com/learnbyinsight.com/wp-content/uploads/2020/09/sub-plot.png?resize=600%2C398&ssl=1"

--- a/website/styles/style.css
+++ b/website/styles/style.css
@@ -1209,6 +1209,40 @@ input {
     padding: 10px;
     border: 1px solid rgba(128, 128, 128, 0.352);
 }
+/* Infinite scroll */
+#examples, #examples2 {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow: hidden;
+    width: 100%;
+}
+
+.examples img {
+    margin-right: 20px; 
+    width: 200px; 
+}
+
+#examples:not(:hover) img,#examples2:not(:hover) img{
+    animation: scrollImages 10s linear infinite;
+}
+
+#examples:hover img, #examples2:hover img {
+    animation-play-state: paused;
+}
+
+
+#examples img:hover, #examples2 img:hover {
+    animation-play-state: paused;
+}
+
+@keyframes scrollImages {
+    0% {
+        transform: translateX(0);
+    }
+    100% {
+        transform: translateX(-100%);
+    }
+}
 /*===========================RESPONSIVE===================================*/
 @media screen and (max-width: 660px) {
     .navbarButton {


### PR DESCRIPTION
### Description

Summary of Changes:
In this pull request, I implemented infinite scrolling for the example images in the index.html file. The scrolling of the images is continuous, and the user can stop the scrolling by hovering over the individual image rows. Additionally, the hover effect on one row will not affect the other row's scrolling behavior, allowing both rows to scroll independently.

Motivation:
The motivation behind this change is to enhance the user experience by making the examples section dynamic, providing a smoother visual flow, and allowing users to interact with the image carousel seamlessly. It allows both rows to scroll independently.

### Related Issue
Fixes # 375

### Type of change
- [ x] Bug fix
- [ x] New feature

### Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
